### PR TITLE
chore: auto create objects in local example

### DIFF
--- a/bento.yml
+++ b/bento.yml
@@ -1,0 +1,25 @@
+input:
+  nats:
+    subject: "cqrl.command.>"
+    urls:
+      - nats://nats:4222
+    queue: bento
+
+
+pipeline:
+  processors:
+    - mapping: |
+        root.specversion = this.specversion
+        root.id = this.id
+        root.source = this.id
+        root.type = "posts"
+        root.datacontenttype = "application/json"
+        root.data = this.data
+        root.data.id = this.id
+        root.time = this.time
+        root.subject = this.id
+
+output:
+  nats:
+    subject: "cqrl.update.posts"
+    urls: ["nats://nats:4222"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,13 @@ services:
     networks:
       - cqrl-network
   nats-listener:
-    image: natsio/nats-box:latest
-    command: nats sub -s nats://nats:4222 "cqrl.command.>"
+    image: ghcr.io/warpstreamlabs/bento:latest
     networks:
       - cqrl-network
+    volumes:
+      - ./bento.yml:/bento.yaml
+    ports:
+      - "4195:4195"
   mongo1:
     image: mongodb/mongodb-community-server:latest
     user: root


### PR DESCRIPTION
Use bento.dev to automatically create objects from the commands that flow through the system